### PR TITLE
If domain is not set, do not force as empty string. Breaks IE.

### DIFF
--- a/lib/cacheable_flash/middleware.rb
+++ b/lib/cacheable_flash/middleware.rb
@@ -16,7 +16,7 @@ module CacheableFlash
       if env_flash
         domain = CacheableFlash::Config.config[:domain]
         cookies = Rack::Request.new(env).cookies
-        Rack::Utils.set_cookie_header!(headers, "flash", :value => cookie_flash(env_flash, cookies), :path => "/", :domain => "#{domain}")
+        Rack::Utils.set_cookie_header!(headers, "flash", :value => cookie_flash(env_flash, cookies), :path => "/", :domain => domain)
       end
 
       [status, headers, body]


### PR DESCRIPTION
Hey @pathouse can you explain https://github.com/pivotal/cacheable-flash/pull/25 a bit? I know this repo is pretty old but I think the merged PR breaks Internet Explorer if a domain is not explicitly set. A set-cookie header does not need quotes.

If domain is explicitly set, master + this PR both render...

```
Set-Cookie: flash=%7B%22error%22%3A%22test123%22%7D; domain=hello; path=/
```

But if domain is nil, master renders... (does not work in IE)

```
Set-Cookie: flash=%7B%22error%22%3A%22test123%22%7D; domain=; path=/
```

While this PR renders...

```
Set-Cookie: flash=%7B%22error%22%3A%22test123%22%7D; path=/
```